### PR TITLE
fix: return 201 Created for POST create operations

### DIFF
--- a/typespec/http-api/services/commentsService.tsp
+++ b/typespec/http-api/services/commentsService.tsp
@@ -27,7 +27,7 @@ interface CommentService {
 
   @useAuth(BearerAuth)
   @post
-  op create(@header contentType: "application/json" | "application/x-www-form-urlencoded", ...NewCommentDto): Comment;
+  op create(@header contentType: "application/json" | "application/x-www-form-urlencoded", ...NewCommentDto): CreatedResponse & Comment;
 
   @useAuth(BearerAuth)
   @patch

--- a/typespec/http-api/services/coursesService.tsp
+++ b/typespec/http-api/services/coursesService.tsp
@@ -26,7 +26,7 @@ interface CourseService {
   ): Course;
 
   @post
-  op create(@header contentType: "application/json" | "application/x-www-form-urlencoded", ...NewCourseDto): Course;
+  op create(@header contentType: "application/json" | "application/x-www-form-urlencoded", ...NewCourseDto): CreatedResponse & Course;
 
   @patch
   op update(@header contentType: "application/json" | "application/x-www-form-urlencoded", @path id: string, ...EditCourseDto): Course;

--- a/typespec/http-api/services/postsService.tsp
+++ b/typespec/http-api/services/postsService.tsp
@@ -26,7 +26,7 @@ interface PostService {
 
   @useAuth(BearerAuth)
   @post
-  op create(@header contentType: "application/json" | "application/x-www-form-urlencoded", ...NewPostDto): Post;
+  op create(@header contentType: "application/json" | "application/x-www-form-urlencoded", ...NewPostDto): CreatedResponse & Post;
 
   @useAuth(BearerAuth)
   @patch

--- a/typespec/http-api/services/tasksService.tsp
+++ b/typespec/http-api/services/tasksService.tsp
@@ -25,7 +25,7 @@ interface TaskService {
   ): Task;
 
   @post
-  op create(@header contentType: "application/json" | "application/x-www-form-urlencoded", ...NewTaskDto): Task;
+  op create(@header contentType: "application/json" | "application/x-www-form-urlencoded", ...NewTaskDto): CreatedResponse & Task;
 
   @patch
   op update(@header contentType: "application/json" | "application/x-www-form-urlencoded", @path id: string, ...EditTaskDto): Task;

--- a/typespec/http-api/services/usersService.tsp
+++ b/typespec/http-api/services/usersService.tsp
@@ -28,7 +28,7 @@ interface UserService {
   ): User;
 
   @post
-  op create(@header contentType: "application/json" | "application/x-www-form-urlencoded", ...NewUserDto): User;
+  op create(@header contentType: "application/json" | "application/x-www-form-urlencoded", ...NewUserDto): CreatedResponse & User;
 
   @useAuth(BearerAuth)
   @patch


### PR DESCRIPTION
## Summary

- All resource creation endpoints (`/tasks`, `/users`, `/posts`, `/comments`, `/courses`) were returning **200 OK** instead of **201 Created**
- Fixed by replacing plain model return types with `CreatedResponse & Model` intersection in TypeSpec definitions
- `authService` (`/login`) intentionally left unchanged — authentication returns 200 by convention

## Root cause

In TypeSpec, returning a bare model type from a `@post` operation generates a 200 response. To signal HTTP 201, the return type must be intersected with `CreatedResponse`:

```diff
- op create(...): Task;
+ op create(...): CreatedResponse & Task;
```

## Test plan

- [ ] Verify `POST /http-api/tasks` returns 201 after deploy
- [ ] Same for `/users`, `/posts`, `/comments`, `/courses`
- [ ] `tsp compile` passes without errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)